### PR TITLE
Make pug template game links dynamic

### DIFF
--- a/src/controllers/indexController.ts
+++ b/src/controllers/indexController.ts
@@ -1,10 +1,10 @@
 import express from 'express';
+import { gameIndexConfigs } from '../config/gameInfo.json';
 
 export const indexController = {
   index(req: express.Request, res: express.Response) {
-    res.render('index.pug', {
-      game: 'Pac-Man',
-    });
+    const gamesList = gameIndexConfigs.slice(1);
+    res.render('index.pug', { gamesList });
   },
 };
 

--- a/views/index.pug
+++ b/views/index.pug
@@ -21,12 +21,12 @@ html
           div Games
           .dropdown-content
             each gameInfo in gamesList
-              a.navtab(onClick='changeActivePage("/games/' + gameInfo.game + '", "' + gameInfo.game + '", "' + gameInfo.name + '")')= gameInfo.name
+              a.navtab(onClick=`changeActivePage("/games/${gameInfo.game}", "${gameInfo.game}", "${gameInfo.name}")`)= gameInfo.name
         .navtab.dropdown
           div High Scores
           .dropdown-content
             each gameInfo in gamesList
-              a.navtab(onClick='changeActivePage("/scores/' + gameInfo.game + '", "' + gameInfo.game + '", "' + gameInfo.name + '")')= gameInfo.name 
+              a.navtab(onClick=`changeActivePage("/scores/'${gameInfo.game}", "${gameInfo.game}", "${gameInfo.name}")`)= gameInfo.name 
         // TODO: remove button when popup is triggered directly on game end
         a.navtab(onClick='scorePopUp()') Submit Score
       #content_window
@@ -40,7 +40,7 @@ html
               .dropdown-content
                 a(onClick='changeChatRoom("general", "General")').clickable General
                 each gameInfo in gamesList
-                  a(onClick='changeChatRoom("' + gameInfo.game + '", "' + gameInfo.name + '")').clickable= gameInfo.name
+                  a(onClick=`changeChatRoom("${gameInfo.game}", "${gameInfo.name}")`).clickable= gameInfo.name
         #chat_messages
         #chat_form
           .input_row

--- a/views/index.pug
+++ b/views/index.pug
@@ -20,11 +20,13 @@ html
         .navtab.dropdown
           div Games
           .dropdown-content
-            a.navtab(onClick='changeActivePage("/games/pacman", "pacman", "Pac-Man")') Pac-Man
+            each gameInfo in gamesList
+              a.navtab(onClick='changeActivePage("/games/' + gameInfo.game + '", "' + gameInfo.game + '", "' + gameInfo.name + '")')= gameInfo.name
         .navtab.dropdown
           div High Scores
           .dropdown-content
-            a.navtab(onClick='changeActivePage("/scores/pacman", "pacman", "Pac-Man")') Pac-Man
+            each gameInfo in gamesList
+              a.navtab(onClick='changeActivePage("/scores/' + gameInfo.game + '", "' + gameInfo.game + '", "' + gameInfo.name + '")')= gameInfo.name 
         // TODO: remove button when popup is triggered directly on game end
         a.navtab(onClick='scorePopUp()') Submit Score
       #content_window
@@ -37,7 +39,8 @@ html
             p#chat_room_label Chat - General &#x25BE;
               .dropdown-content
                 a(onClick='changeChatRoom("general", "General")').clickable General
-                a(onClick='changeChatRoom("pacman", "Pac-Man")').clickable Pac-Man
+                each gameInfo in gamesList
+                  a(onClick='changeChatRoom("' + gameInfo.game + '", "' + gameInfo.name + '")').clickable= gameInfo.name
         #chat_messages
         #chat_form
           .input_row

--- a/views/nexus.pug
+++ b/views/nexus.pug
@@ -11,9 +11,9 @@ html
       #gameGrid
         each gameInfo in gamesList
           a.gameTile(href='/games/' + gameInfo.game)
-            img(src='/images/pacman_thumbnail.png')
+            img(src='/images/' + gameInfo.game + '_thumbnail.png')
             .gameInfo
-              .gameName Pac-Man
+              .gameName= gameInfo.name
               .description Play the classic arcade game here!
         .gameTile
           img(src='/images/kubercade logo.png')

--- a/views/nexus.pug
+++ b/views/nexus.pug
@@ -10,8 +10,8 @@ html
       h4 Nexus - Browse Games
       #gameGrid
         each gameInfo in gamesList
-          a.gameTile(href='/games/' + gameInfo.game)
-            img(src='/images/' + gameInfo.game + '_thumbnail.png')
+          a.gameTile(href=`/games/${gameInfo.game}`)
+            img(src=`/images/${gameInfo.game}_thumbnail.png`)
             .gameInfo
               .gameName= gameInfo.name
               .description Play the classic arcade game here!


### PR DESCRIPTION
Use pug iteration to dynamically add content to the navigation bar, nexus, and chat based off the games listed in `src/config/gameInfo.json`. When we want to support new games, just add their info the config file and the relevant link, chatrooms, etc. will be added to the UI.

https://screenshot.googleplex.com/Tvj7FJsCF35