### PR TITLE
Fire pacmanLoad event directly on iframe load

### DIFF
--- a/views/index.pug
+++ b/views/index.pug
@@ -28,12 +28,13 @@ html
           div High Scores
           .dropdown-content
             each gameInfo in gamesList
-              a.navtab(onClick=`changeActivePage("/scores/'${gameInfo.game}", "${gameInfo.game}", "${gameInfo.name}")`)= gameInfo.name 
+              a.navtab(onClick=`changeActivePage("/scores/${gameInfo.game}", "${gameInfo.game}", "${gameInfo.name}")`)= gameInfo.name 
         // TODO: remove button when popup is triggered directly on game end
         a.navtab(onClick='scorePopUp()') Submit Score
       #content_window
         iframe#kubercade_iframe(
-          src='/nexus'
+          src='/nexus',
+          onLoad='iframeChange(this.contentWindow.location)'
         )
       #chat_window
         #chat_top_bar

--- a/views/js/navigation.js
+++ b/views/js/navigation.js
@@ -7,7 +7,11 @@ const changeActivePage = (url, chatRoom, gameName) => {
 
 const changeIframePage = (url) => {
   document.getElementById('kubercade_iframe').src = url;
-  if (url === '/games/pacman') {
+}
+
+// fires appropriate events on iframe location change
+const iframeChange = (url) => {
+  if (String(url).endsWith('/games/pacman') || String(url).endsWith('/games/pacman/')) {
     document.dispatchEvent(pacmanLoadEvent);
   }
 }

--- a/views/js/submitScore.js
+++ b/views/js/submitScore.js
@@ -1,15 +1,13 @@
+// pacmanLoad is fired whenver iframe loads /games/pacman
 document.addEventListener('pacmanLoad', () => {
   const iframe = document.getElementById("kubercade_iframe");
-  iframe.addEventListener("load", () => {
-    const iframeWindow = iframe.contentWindow;
-    const origGameover = iframeWindow.gameover;
-    iframeWindow.gameover = () => {
-      score = getPacmanScore(iframe)
-      origGameover();
-      scorePopUp(score, "/scores/pacman/");
-    }
-  },
-  { once: true });
+  const iframeWindow = iframe.contentWindow;
+  const origGameover = iframeWindow.gameover;
+  iframeWindow.gameover = () => {
+    score = getPacmanScore(iframe)
+    origGameover();
+    scorePopUp(score, "/scores/pacman/");
+  }
 });
 
 const getPacmanScore = (iframe) => {


### PR DESCRIPTION
Originally, the `pacmanLoad` event would only be fired when `games/pacman` was accessed from the navbar, and not when it was accessed from the nexus. This would lead to the `gameover` function not being patched in that case.

Added a function that fires game load events directly when the iframe loads a new page, removing any dependency on where a game is reached from. Should be easy to add new games to this.