### PR TITLE
Improve timing of gameover

### DIFF
--- a/src/controllers/scoresController.ts
+++ b/src/controllers/scoresController.ts
@@ -43,6 +43,7 @@ export const scoresController = {
 async function getScoresFromDB(gameIndex: number): Promise<object[]> {
   try {
     const res = await pool.query(
+      // "DELETE FROM kubercade.high_score_table"  take this out! for debugging
       `SELECT *
       FROM kubercade.high_score_table
       WHERE game_index=$1

--- a/views/index.pug
+++ b/views/index.pug
@@ -28,12 +28,13 @@ html
           div High Scores
           .dropdown-content
             each gameInfo in gamesList
-              a.navtab(onClick=`changeActivePage("/scores/'${gameInfo.game}", "${gameInfo.game}", "${gameInfo.name}")`)= gameInfo.name 
+              a.navtab(onClick=`changeActivePage("/scores/${gameInfo.game}", "${gameInfo.game}", "${gameInfo.name}")`)= gameInfo.name 
         // TODO: remove button when popup is triggered directly on game end
         a.navtab(onClick='scorePopUp()') Submit Score
       #content_window
         iframe#kubercade_iframe(
-          src='/nexus'
+          src='/nexus',
+          onLoad='iframeChange(this.contentWindow.location)'
         )
       #chat_window
         #chat_top_bar

--- a/views/js/navigation.js
+++ b/views/js/navigation.js
@@ -13,5 +13,7 @@ const changeIframePage = (url) => {
 const iframeChange = (url) => {
   if (String(url).endsWith('/games/pacman') || String(url).endsWith('/games/pacman/')) {
     document.dispatchEvent(pacmanLoadEvent);
+    // makes sures chat room changes when coming from nexus
+    changeChatRoom('pacman', 'Pac-Man');
   }
 }

--- a/views/js/navigation.js
+++ b/views/js/navigation.js
@@ -7,7 +7,11 @@ const changeActivePage = (url, chatRoom, gameName) => {
 
 const changeIframePage = (url) => {
   document.getElementById('kubercade_iframe').src = url;
-  if (url === '/games/pacman') {
+}
+
+// fires appropriate events on iframe location change
+const iframeChange = (url) => {
+  if (String(url).endsWith('/games/pacman') || String(url).endsWith('/games/pacman/')) {
     document.dispatchEvent(pacmanLoadEvent);
   }
 }

--- a/views/js/submitScore.js
+++ b/views/js/submitScore.js
@@ -1,15 +1,13 @@
+// pacmanLoad is fired whenver iframe loads /games/pacman
 document.addEventListener('pacmanLoad', () => {
   const iframe = document.getElementById("kubercade_iframe");
-  iframe.addEventListener("load", () => {
-    const iframeWindow = iframe.contentWindow;
-    const origGameover = iframeWindow.gameover;
-    iframeWindow.gameover = () => {
-      score = getPacmanScore(iframe)
-      origGameover();
-      scorePopUp(score, "/scores/pacman/");
-    }
-  },
-  { once: true });
+  const iframeWindow = iframe.contentWindow;
+  const origGameover = iframeWindow.gameover;
+  iframeWindow.gameover = () => {
+    score = getPacmanScore(iframe)
+    origGameover();
+    scorePopUp(score, "/scores/pacman/");
+  }
 });
 
 const getPacmanScore = (iframe) => {

--- a/views/js/submitScore.js
+++ b/views/js/submitScore.js
@@ -6,7 +6,10 @@ document.addEventListener('pacmanLoad', () => {
   iframeWindow.gameover = () => {
     score = getPacmanScore(iframe)
     origGameover();
-    scorePopUp(score, "/scores/pacman/");
+    // Wait for 'Game Over' to display in game
+    setTimeout(() => {
+        scorePopUp(score, "/scores/pacman/");
+      }, 500);
   }
 });
 
@@ -25,8 +28,11 @@ const scorePopUp = (score, scoreUrl) => {
   sendScore(scoreUrl, {
     name,
     score
-  }).then(() =>
-    {changeIframePage(scoreUrl) });
+  }).then(() => {
+    setTimeout(() => {
+      changeIframePage(scoreUrl);
+    }, 100);
+  });
 }
 
 const sendScore = (url, data) => {


### PR DESCRIPTION
Added a timeout so that the "Game Over" message can display on pacman before the name submit alert pop ups - implemented in the same was as in #33.

There also seemed to be a tiny bit of lag in adding the score to the DB, so the most recent score was usually added after the scores were retrieved for display. Fixed this with a timeout before going to the high scores page after the game ends.