### PR TITLE
Fix scores search style

### DIFF
--- a/views/style.css
+++ b/views/style.css
@@ -376,7 +376,7 @@ a.gameTile:hover {
 
 #high_scores_container #scores_list {
   width: 100%;
-  max-width: 1200px;
+  max-width: 1600px;
   overflow-y: auto;
 }
 

--- a/views/style.css
+++ b/views/style.css
@@ -352,8 +352,8 @@ a.gameTile:hover {
   display: flex;
   flex-wrap: nowrap;
   margin-bottom: 48px;
-  width: 100%;
-  max-width: 400px;
+  width: 90%;
+  max-width: 600px;
 }
 
 #high_scores_container #score_filter .icon {
@@ -366,10 +366,12 @@ a.gameTile:hover {
   background: white;
   color: black;
   flex-grow: 1;
-  font-size: 24pt;
+  font-size: 16pt;
   padding: 4px 8px;
   font-family: 'Press Start 2P',
     sans-serif;
+  width: 0;
+  /* Allow input to shrink with flexbox */
 }
 
 #high_scores_container #scores_list {


### PR DESCRIPTION
Styling for the score filter/search box was a little wonky for some reason, not sure why but this makes it better (centered, reasonable font size, fit on screen).

Before:
https://screenshot.googleplex.com/nbGvNfGZiCo
https://screenshot.googleplex.com/Ds9sNMNK7Ec

After:
https://screenshot.googleplex.com/UuHHA2SDcTY
https://screenshot.googleplex.com/yKssiuLfnBJ