### PR TITLE
Run on Google Cloud button

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ This app is set up to easily deploy to any platform built on [Knative](https://k
 [![Run on Google Cloud](https://storage.googleapis.com/cloudrun/button.svg)](https://console.cloud.google.com/cloudshell/editor?shellonly=true&cloudshell_image=gcr.io/cloudrun/button&cloudshell_git_repo=https://github.com/knative-portability/Kubercade.git)
 
 You also need to setup a PostgreSQL database and enter its connection string when prompted by Google Cloud Shell.
+I.e. `postgres://{username}:{password}@{host}/{database}`

--- a/README.md
+++ b/README.md
@@ -4,4 +4,12 @@
 
 [![Code Style: Google](https://img.shields.io/badge/code%20style-google-blueviolet.svg)](https://github.com/google/gts)
 
-Serverless containerized social arcade built on Knative.
+Serverless containerized social arcade built on [Knative](https://knative.dev/).
+
+## Deploy
+
+This app is set up to easily deploy to any platform built on [Knative](https://knative.dev/). You can try it on [Google Cloud Run](https://cloud.google.com/run/) using this button.
+
+[![Run on Google Cloud](https://storage.googleapis.com/cloudrun/button.svg)](https://console.cloud.google.com/cloudshell/editor?shellonly=true&cloudshell_image=gcr.io/cloudrun/button&cloudshell_git_repo=https://github.com/knative-portability/Kubercade.git)
+
+You also need to setup a PostgreSQL database and enter its connection string when prompted by Google Cloud Shell.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Serverless containerized social arcade built on [Knative](https://knative.dev/).
 
 ## Deploy
 
-This app is set up to easily deploy to any platform built on [Knative](https://knative.dev/). You can try it on [Google Cloud Run](https://cloud.google.com/run/) using this button.
+This app easily deploys to any platform built on [Knative](https://knative.dev/). You can try it on [Google Cloud Run](https://cloud.google.com/run/) using this button.
 
 [![Run on Google Cloud](https://storage.googleapis.com/cloudrun/button.svg)](https://console.cloud.google.com/cloudshell/editor?shellonly=true&cloudshell_image=gcr.io/cloudrun/button&cloudshell_git_repo=https://github.com/knative-portability/Kubercade.git)
 
-You also need to setup a PostgreSQL database and enter its connection string when prompted by Google Cloud Shell.
+You also need to setup a PostgreSQL database and initialize it by executing [src/.schema.sql](src/.schema.sql). Once you've done that, enter its connection string when prompted by Google Cloud Shell.
 I.e. `postgres://{username}:{password}@{host}/{database}`

--- a/app.json
+++ b/app.json
@@ -1,0 +1,8 @@
+{
+  "name": "Kubercade",
+  "env": {
+    "DB_URL": {
+      "description": "the connection string for your PostgreSQL instance"
+    }
+  }
+}


### PR DESCRIPTION
As per Weston's suggestion, a button to "Run on Google Cloud."
Also includes an app.json file which lets us specify the name of the deploy and require the user enters a `DB_URL` environment variable.

https://screenshot.googleplex.com/ZjWwCQkWG8Z