### PR TITLE
Fix game over patching handlers

### DIFF
--- a/views/js/submitScore.js
+++ b/views/js/submitScore.js
@@ -33,7 +33,6 @@ document.addEventListener('2048Load', () => {
   // wait until gameManagerInstance is created during page animation
   iframeWindow.addEventListener('animationend', () => {
     const actuator = iframeWindow.gameManagerInstance.actuator;
-    console.log(actuator);
     actuator.origMessage = actuator.message;
     actuator.message = () => {
       actuator.origMessage();


### PR DESCRIPTION
Removed redundant inner `load` handler for patching game over for Arkanoid, 2048, and Tetris, since the outer events (e.g `tetrisLoad`) only occur after the iframe is done loading. Games should work when accessed from nexus now.

Had some issues with 2048 since `gameManagerInstance` was created during page animations, after page load. I fixed this with an `animationend` event handler. 
