### PR TITLE
Fix minesweeper double alert

### DIFF
--- a/vendor/minesweeper/ATTRIBUTION.md
+++ b/vendor/minesweeper/ATTRIBUTION.md
@@ -10,4 +10,8 @@ https://github.com/reed-jones
 
 The minesweeper_js repository is used in Kubercade as a Minesweeper-like game. The original repository's code was imported into the `vendor` directory and run as static files.
 
-The original source code was not modified in order to integrate with the Kubercade high scores functionality. Instead, the `winGame` function from `main.js` is patched upon game load. 
+Some modifications were made to the original source code file `main.js` in order to facilitate integration with the Kubercade high-score system:
+
+- A window alert in `addScores` was removed to prevent having a double alert on game win.
+
+Additionally, the `winGame` function from `main.js` is patched upon game load without direct modification of the original code.

--- a/vendor/minesweeper/main.js
+++ b/vendor/minesweeper/main.js
@@ -788,7 +788,7 @@ function addScores() {
     }
 
     //time = parseInt(seconds.innerHTML);
-    var s = prompt("Congratulations, you finished in " + time + " seconds!\nEnter your name if you wish to be added to the High score table:");
+    // var s = prompt("Congratulations, you finished in " + time + " seconds!\nEnter your name if you wish to be added to the High score table:");
 
     if (s !== null) {
         postScore(s, time, difficulty);


### PR DESCRIPTION
So somehow I managed to not play through minesweeper fully until now - The original app also raises an alert on win, giving the user 2 alerts total which is annoying.

Removed the alert from the original game and updated `ATTRIBUTION.md`.