### PR TITLE
Fix Deploy on Google Cloud button for demo

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
-  "name": "Kubercade",
+  "name": "kubercade",
   "env": {
     "DB_URL": {
       "description": "the connection string for your PostgreSQL instance"


### PR DESCRIPTION
Lowercase the project name so Deploy on Google Cloud button doesn't get "invalid reference format: repository name must be lowercase" from Docker.